### PR TITLE
disable timeout and add bailout feature to bypass queue for deferrable views

### DIFF
--- a/apps/imports-orchestrator-example/src/app/app.config.ts
+++ b/apps/imports-orchestrator-example/src/app/app.config.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/router';
 import { appRoutes } from './app.routes';
 import {
-  provideDeferQueue,
+  provideDeferQueue, withBailout,
   withConcurrencyUpdateFn,
   withSuspendWhileRouting,
   withTimeout,
@@ -14,7 +14,7 @@ import {
 import {
   provideImportsOrchestration,
   withConcurrencyRelativeToDownlinkSpeed,
-  withInterceptor,
+  withInterceptor, withLogger,
 } from '@lotto24-angular/imports-orchestrator';
 
 const APP_IMPORTS_ORCHESTRATION = {
@@ -53,6 +53,33 @@ const APP_IMPORTS_ORCHESTRATION = {
   serviceComponent: 601,
 };
 
+
+export class NullLogger  {
+  public log(_message: any) {
+    // noop
+  }
+
+  public info(_message: any) {
+    // noop
+  }
+
+  public error(_message: any, _trace?: string) {
+    // noop
+  }
+
+  public warn(_message: any) {
+    // noop
+  }
+
+  public debug(_message: string) {
+    // noop
+  }
+
+  public verbose(_message: string) {
+    // noop
+  }
+}
+
 export type AppImportsOrchestration = typeof APP_IMPORTS_ORCHESTRATION;
 export const appConfig = {
   providers: [
@@ -63,6 +90,7 @@ export const appConfig = {
       withPreloading(NoPreloading)
     ),
     provideDeferQueue(
+      withBailout(),
       withConcurrencyUpdateFn(downlinkToConcurrencyFn(8, 2)),
       withSuspendWhileRouting(),
       withTimeout(2000),
@@ -81,6 +109,7 @@ export const appConfig = {
           console.log('interceptor, error', identifier)
         );
       }),
+      withLogger(new NullLogger()),
       // withSuspendWhileRoutingForImportsOrchestrator(),
       withConcurrencyRelativeToDownlinkSpeed(2, 1)
     ),

--- a/apps/imports-orchestrator-example/src/app/app.config.ts
+++ b/apps/imports-orchestrator-example/src/app/app.config.ts
@@ -5,7 +5,12 @@ import {
   withPreloading,
 } from '@angular/router';
 import { appRoutes } from './app.routes';
-import {provideDeferQueue, withConcurrencyStatic, withSuspendWhileRouting, withTimeout} from 'defer-queue';
+import {
+  provideDeferQueue,
+  withConcurrencyUpdateFn,
+  withSuspendWhileRouting,
+  withTimeout,
+} from 'defer-queue';
 import {
   provideImportsOrchestration,
   withConcurrencyRelativeToDownlinkSpeed,
@@ -58,7 +63,7 @@ export const appConfig = {
       withPreloading(NoPreloading)
     ),
     provideDeferQueue(
-      withConcurrencyStatic(1),
+      withConcurrencyUpdateFn(downlinkToConcurrencyFn(8, 2)),
       withSuspendWhileRouting(),
       withTimeout(2000),
     ),
@@ -81,3 +86,27 @@ export const appConfig = {
     ),
   ],
 };
+
+export function downlinkToConcurrencyFn(max: number, min: number = 1): () => number {
+  return () => {
+    const downlink = (navigator as any).connection?.downlink;
+
+    if (!downlink) {
+      // if devices do not provide a downlink speed, assign min concurrency for mobile devices and max concurrency for larger devices
+      return screen.width < 768 ? min : max;
+    }
+
+    if (downlink < 5) {
+      // 4G, 3G
+      return min;
+    } else if (downlink < 10) {
+      // DSL
+      return Math.max(min, Math.floor(min + (max - min) / 4));
+    } else if (downlink < 30) {
+      // slow WIFI
+      return Math.max(min, Math.floor(min + (max - min) / 2));
+    }
+
+    return max;
+  };
+}

--- a/libs/defer-queue/src/lib/features/bailout.ts
+++ b/libs/defer-queue/src/lib/features/bailout.ts
@@ -1,0 +1,22 @@
+import {
+  deferQueueFeature,
+  DeferQueueFeatureBailout,
+  DeferQueueFeatureKind,
+} from './internal';
+import { Provider } from '@angular/core';
+import { DEFER_QUEUE_FEATURE_BAILOUT } from '../token';
+
+/**
+ * Using this feature will initialize the signal for deferrable view conditions with true by default
+ * effectively bypassing the condition.
+ * @param value
+ */
+export function withBailout(value: boolean = true): DeferQueueFeatureBailout {
+  const providers: Provider[] = [
+    {
+      provide: DEFER_QUEUE_FEATURE_BAILOUT,
+      useValue: value,
+    },
+  ];
+  return deferQueueFeature(DeferQueueFeatureKind.Bailout, providers);
+}

--- a/libs/defer-queue/src/lib/features/concurrency.ts
+++ b/libs/defer-queue/src/lib/features/concurrency.ts
@@ -17,3 +17,20 @@ export function withConcurrencyStatic(
   ];
   return deferQueueFeature(DeferQueueFeatureKind.Concurrency, providers);
 }
+
+
+/**
+ * @param onUpdateConcurrencyFn called when queue processor updates concurrency;
+ */
+export function withConcurrencyUpdateFn(
+  onUpdateConcurrencyFn: () => number
+): DeferQueueFeatureConcurrency {
+  const providers: Provider[] = [
+    {
+      provide: DEFER_QUEUE_FEATURE_CONCURRENCY,
+      useValue: onUpdateConcurrencyFn,
+    },
+  ];
+
+  return deferQueueFeature(DeferQueueFeatureKind.Concurrency, providers);
+}

--- a/libs/defer-queue/src/lib/features/index.ts
+++ b/libs/defer-queue/src/lib/features/index.ts
@@ -1,3 +1,4 @@
+export * from './bailout';
 export * from './concurrency';
 export * from './logger';
 export * from './queue';

--- a/libs/defer-queue/src/lib/features/internal.ts
+++ b/libs/defer-queue/src/lib/features/internal.ts
@@ -1,5 +1,7 @@
 import { Provider } from '@angular/core';
 
+export type DeferQueueFeatureBailout =
+  DeferQueueFeature<DeferQueueFeatureKind.Bailout>;
 export type DeferQueueFeatureConcurrency =
   DeferQueueFeature<DeferQueueFeatureKind.Concurrency>;
 export type DeferQueueFeatureLogger =
@@ -17,6 +19,7 @@ export enum DeferQueueFeatureKind {
   Routing,
   Concurrency,
   Timeout,
+  Bailout,
 }
 
 export type DeferQueueFeature<T extends DeferQueueFeatureKind> = {

--- a/libs/defer-queue/src/lib/provide.ts
+++ b/libs/defer-queue/src/lib/provide.ts
@@ -1,20 +1,25 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import {
+  withBailout,
   withConcurrencyStatic,
-  withLogger, withoutRouting,
+  withLogger,
+  withoutRouting,
   withQueue,
   withTimeout,
 } from './features';
 import { Queue } from './queue/queue';
 import {
+  DeferQueueFeatureBailout,
   DeferQueueFeatureConcurrency,
   DeferQueueFeatureLogger,
-  DeferQueueFeatureQueue, DeferQueueFeatureRouting,
+  DeferQueueFeatureQueue,
+  DeferQueueFeatureRouting,
   DeferQueueFeatureTimeout,
 } from './features/internal';
 import { DeferQueueItem } from './service';
 
 export type DeferQueueFeatures = (
+  | DeferQueueFeatureBailout
   | DeferQueueFeatureConcurrency
   | DeferQueueFeatureLogger
   | DeferQueueFeatureQueue
@@ -27,6 +32,7 @@ export const provideDeferQueue = <O>(
 ): EnvironmentProviders =>
   makeEnvironmentProviders([
     ...[
+      withBailout(false),
       withConcurrencyStatic(1),
       withLogger(console),
       withQueue(new Queue<DeferQueueItem>()),

--- a/libs/defer-queue/src/lib/queue/defer-queue-processor.service.ts
+++ b/libs/defer-queue/src/lib/queue/defer-queue-processor.service.ts
@@ -2,10 +2,11 @@ import { inject, Injectable } from '@angular/core';
 import {
   DEFER_QUEUE_FEATURE_CONCURRENCY,
   DEFER_QUEUE_FEATURE_LOGGER,
-  DEFER_QUEUE_FEATURE_QUEUE, DEFER_QUEUE_FEATURE_ROUTING,
+  DEFER_QUEUE_FEATURE_QUEUE,
+  DEFER_QUEUE_FEATURE_ROUTING,
 } from '../token';
 import { wait } from '../util/wait';
-import {filter, firstValueFrom, tap} from "rxjs";
+import { filter, firstValueFrom, tap } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class DeferQueueProcessor {
@@ -48,7 +49,6 @@ export class DeferQueueProcessor {
     await wait();
     // ^^
 
-
     const concurrency = this.updateConcurrency();
     const concurrentBatch = [];
     for (let i = this.running; i < concurrency; i++) {
@@ -56,7 +56,7 @@ export class DeferQueueProcessor {
       concurrentBatch.push(this.processItem());
     }
     this.logger.debug(
-      `queue starting ${concurrentBatch.length} item(s) to reach max concurrency (running=${this.running})`
+      `queue starting ${concurrentBatch.length} item(s) to reach max concurrency (concurrency=${concurrency}, running=${this.running})`
     );
     await Promise.all(concurrentBatch);
   }
@@ -84,18 +84,10 @@ export class DeferQueueProcessor {
   }
 
   private updateConcurrency(): number {
-    const value =
-      typeof this.concurrency === 'function'
+    return typeof this.concurrency === 'function'
         ? this.concurrency()
         : this.concurrency;
-
-    if (value !== this.concurrency) {
-      this.logger.debug(`queue concurrency changed to ${value}`);
-    }
-
-    return value;
   }
-
 
   private async suspendForNavigation(): Promise<unknown> {
     // suspend processing while routing, as navigation takes precedence

--- a/libs/defer-queue/src/lib/service.ts
+++ b/libs/defer-queue/src/lib/service.ts
@@ -79,6 +79,7 @@ export class DeferQueue {
           `resolving deferrable w/ identifier=${identifier} because injection context was destroyed`
         );
         deferrable.resolve();
+        this.deferrableStore.delete(identifier);
       });
       return deferrable.triggered();
     };
@@ -117,7 +118,9 @@ export class DeferQueue {
       const resolved = () =>
         new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => {
-            this.logger.error(`timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`);
+            this.logger.error(
+              `timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`
+            );
             deferrable.resolve();
           }, this.timeout);
 

--- a/libs/defer-queue/src/lib/service.ts
+++ b/libs/defer-queue/src/lib/service.ts
@@ -10,6 +10,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import {
+  DEFER_QUEUE_FEATURE_BAILOUT,
   DEFER_QUEUE_FEATURE_LOGGER,
   DEFER_QUEUE_FEATURE_QUEUE,
   DEFER_QUEUE_FEATURE_TIMEOUT,
@@ -47,6 +48,7 @@ export interface ObservableState<V> {
 })
 export class DeferQueue {
   private readonly queueProcessor = inject(DeferQueueProcessor);
+  private readonly bailout = inject(DEFER_QUEUE_FEATURE_BAILOUT);
   private readonly timeout = inject(DEFER_QUEUE_FEATURE_TIMEOUT);
   private readonly logger = inject(DEFER_QUEUE_FEATURE_LOGGER);
   private readonly queue = inject(DEFER_QUEUE_FEATURE_QUEUE);
@@ -73,30 +75,7 @@ export class DeferQueue {
       identifier: string,
       priority: DeferQueueItemPriority = 'default'
     ) => {
-      const deferrable = this.deferrable(identifier, priority);
-
-      let timeoutId: number = -1;
-      const onErrorFn = (msg: string) => () => {
-        this.logger.error(msg);
-        deferrable.resolve();
-        clearTimeout(timeoutId);
-        this.deferrableStore.delete(identifier);
-      };
-
-      timeoutId = setTimeout(
-        onErrorFn(
-          `timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`
-        ),
-        this.timeout
-      );
-
-      destroyRef.onDestroy(
-        onErrorFn(
-          `resolving deferrable w/ identifier=${identifier} because injection context was destroyed`
-        )
-      );
-
-      return deferrable.triggered();
+      return this.deferrable(identifier, priority, destroyRef).triggered();
     };
   }
 
@@ -117,11 +96,12 @@ export class DeferQueue {
    */
   private deferrable(
     identifier: string,
-    priority: DeferQueueItemPriority = 'default'
+    priority: DeferQueueItemPriority = 'default',
+    destroyRef: DestroyRef,
   ) {
     if (!this.deferrableStore.has(identifier)) {
       const deferrable: DeferQueueDeferrable = {
-        triggered: signal(false),
+        triggered: signal(this.bailout),
         resolve: () => {
           const taken = this.queue.take(item);
           this.logger.info(
@@ -152,6 +132,27 @@ export class DeferQueue {
       );
       this.queue.insert(fromDeferQueueItemPriority(priority), item);
       this.queueProcessor.process();
+
+      // let timeoutId: number = -1;
+      // const onErrorFn = (msg: string) => () => {
+      //   this.logger.error(msg);
+      //   deferrable.resolve();
+      //   clearTimeout(timeoutId);
+      //   this.deferrableStore.delete(identifier);
+      // };
+      //
+      // timeoutId = setTimeout(
+      //   onErrorFn(
+      //     `timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`
+      //   ),
+      //   this.timeout
+      // );
+      //
+      // destroyRef.onDestroy(
+      //   onErrorFn(
+      //     `resolving deferrable w/ identifier=${identifier} because injection context was destroyed`
+      //   )
+      // );
     }
 
     return this.deferrableStore.get(identifier) as DeferQueueDeferrable;

--- a/libs/defer-queue/src/lib/service.ts
+++ b/libs/defer-queue/src/lib/service.ts
@@ -115,21 +115,21 @@ export class DeferQueue {
         },
       };
 
+      const timeout = setTimeout(() => {
+        this.logger.error(
+          `timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`
+        );
+        deferrable.resolve();
+      }, this.timeout);
+
       const resolved = () =>
         new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(() => {
-            this.logger.error(
-              `timeout after ${this.timeout}ms for deferrable w/ identifier=${identifier}, priority=${priority}`
-            );
-            deferrable.resolve();
-          }, this.timeout);
-
           deferrable.resolve = (err?: unknown) => {
             if (err) {
               reject(err);
             } else {
-              resolve();
               clearTimeout(timeout);
+              resolve();
               this.logger.info(
                 `resolved deferrable w/ identifier=${identifier}, priority=${priority}`
               );

--- a/libs/defer-queue/src/lib/token.ts
+++ b/libs/defer-queue/src/lib/token.ts
@@ -3,6 +3,8 @@ import { Queue } from './queue/queue';
 import { DeferQueueItem } from './service';
 import {Observable} from "rxjs";
 
+export const DEFER_QUEUE_FEATURE_BAILOUT = new InjectionToken<boolean>('DEFER_QUEUE_FEAUTURE_BAILOUT');
+
 export const DEFER_QUEUE_FEATURE_CONCURRENCY = new InjectionToken<
   number | (() => number)
 >('DEFER_QUEUE_FEAUTURE_CONCURRENCY');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lotto24-angular",
-  "version": "0.4.4",
+  "version": "0.4.5-prerelease.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lotto24-angular",
-      "version": "0.4.4",
+      "version": "0.4.5-prerelease.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "17.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lotto24-angular",
-  "version": "0.4.2-prerelease.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lotto24-angular",
-      "version": "0.4.2-prerelease.0",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "17.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lotto24-angular",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lotto24-angular",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "17.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lotto24-angular",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lotto24-angular",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "17.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lotto24-angular",
-  "version": "0.4.1",
+  "version": "0.4.2-prerelease.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lotto24-angular",
-      "version": "0.4.1",
+      "version": "0.4.2-prerelease.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "17.2.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepare": "husky install",
     "prepare-imports-orchestrator-example": "nx run imports-orchestrator-example:prepare"
   },
-  "version": "0.4.2-prerelease.0",
+  "version": "0.4.2",
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.21"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepare": "husky install",
     "prepare-imports-orchestrator-example": "nx run imports-orchestrator-example:prepare"
   },
-  "version": "0.4.2",
+  "version": "0.4.3",
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.21"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepare": "husky install",
     "prepare-imports-orchestrator-example": "nx run imports-orchestrator-example:prepare"
   },
-  "version": "0.4.4",
+  "version": "0.4.5-prerelease.0",
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.21"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepare": "husky install",
     "prepare-imports-orchestrator-example": "nx run imports-orchestrator-example:prepare"
   },
-  "version": "0.4.3",
+  "version": "0.4.4",
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.21"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepare": "husky install",
     "prepare-imports-orchestrator-example": "nx run imports-orchestrator-example:prepare"
   },
-  "version": "0.4.1",
+  "version": "0.4.2-prerelease.0",
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.21"


### PR DESCRIPTION
- remove items from storage when resolving them upon destruction
- 0.4.2-prerelease.0
- 0.4.2
- defer-queue: add support for concurrency update function
- 0.4.3
- bugfix: timeout not triggering
- 0.4.4
- improve timeout and ondestroy callbacks
- add feature bailout to bypass queue processing for deferrable views easily
- 0.4.5-prerelease.0
